### PR TITLE
feat: Add language support for instructors

### DIFF
--- a/src/features/Instructors/components/InstructorCard.svelte
+++ b/src/features/Instructors/components/InstructorCard.svelte
@@ -41,6 +41,25 @@
 				{/each}
 			</div>
 
+			<!-- Languages Spoken -->
+			{#if instructorData.spokenLanguages && instructorData.spokenLanguages.length > 0}
+				<div class="flex flex-row items-center gap-2">
+					<img src="/icons/language.svg" alt="Languages" class="size-4" />
+					<div class="flex flex-row items-center gap-1 flex-wrap">
+						{#each instructorData.spokenLanguages.slice(0, 3) as language}
+							<Badge variant="secondary" class="text-[0.65rem] sm:text-xs">
+								{language}
+							</Badge>
+						{/each}
+						{#if instructorData.spokenLanguages.length > 3}
+							<span class="text-[0.65rem] text-muted-foreground sm:text-xs">
+								+{instructorData.spokenLanguages.length - 3} more
+							</span>
+						{/if}
+					</div>
+				</div>
+			{/if}
+
 			<!-- Teaching Location -->
 			<div class="flex flex-row items-center gap-2">
 				<img src="/icons/ski-resort.svg" alt="Resort" class="size-4" />

--- a/src/features/Instructors/components/InstructorProfileForm.svelte
+++ b/src/features/Instructors/components/InstructorProfileForm.svelte
@@ -14,6 +14,7 @@
 	import { instructorProfileSchema, type InstructorProfileSchema } from '../lib/instructorSchemas';
 	import SearchResort from '$src/features/Resorts/components/SearchResort.svelte';
 	import SportsCheckboxes from '$src/features/Sports/components/SportsCheckboxes.svelte';
+	import LanguageCheckboxes from '$src/lib/components/shared/LanguageCheckboxes.svelte';
 	import { onDestroy, onMount } from 'svelte';
 	import CountryCodeSelect from '$src/lib/components/shared/CountryCodeSelect.svelte';
 	import { toast } from 'svelte-sonner';
@@ -178,6 +179,9 @@
 
 				<!-- Sports -->
 				<SportsCheckboxes {form} name="sports" />
+
+				<!-- Languages -->
+				<LanguageCheckboxes {form} name="spokenLanguages" />
 			</Accordion.Content>
 		</Accordion.Item>
 

--- a/src/features/Instructors/components/InstructorSignupForm.svelte
+++ b/src/features/Instructors/components/InstructorSignupForm.svelte
@@ -13,6 +13,7 @@
 	import { instructorSignupSchema, type InstructorSignupSchema } from '../lib/instructorSchemas';
 	import SearchResort from '$src/features/Resorts/components/SearchResort.svelte';
 	import SportsCheckboxes from '$src/features/Sports/components/SportsCheckboxes.svelte';
+	import LanguageCheckboxes from '$src/lib/components/shared/LanguageCheckboxes.svelte';
 	import { onDestroy } from 'svelte';
 	import CurrencySelect from '$src/lib/components/shared/CurrencySelect.svelte';
 	import CountryCodeSelect from '$src/lib/components/shared/CountryCodeSelect.svelte';
@@ -164,7 +165,9 @@
 	</Form.Field>
 
 	<SportsCheckboxes {form} name="sports" />
-	
+
+	<LanguageCheckboxes {form} name="spokenLanguages" />
+
 	<div class="flex w-full flex-col gap-2 sm:flex-row">
 		<Form.Field {form} name="basePrice" class="w-full">
 			<Form.Control>

--- a/src/features/Instructors/lib/instructorRepository.ts
+++ b/src/features/Instructors/lib/instructorRepository.ts
@@ -16,6 +16,7 @@ export interface InstructorData {
     professionalPhone?: string;
     bio?: string;
     sports?: number[];
+    spokenLanguages?: string[];
     basePrice?: number;
     currency?: string;
 }
@@ -33,6 +34,7 @@ export class InstructorRepository {
                     professionalCountryCode: instructorData.professionalCountryCode.toString(),
                     professionalPhone: instructorData.professionalPhone,
                     bio: instructorData.bio,
+                    spokenLanguages: instructorData.spokenLanguages,
                     updatedAt: new Date()
                 })
                 .where(eq(users.id, instructorData.userId))
@@ -99,13 +101,14 @@ export class InstructorRepository {
         return await db.transaction(async (tx) => {
             // Update user fields
             const userUpdateFields: Partial<InsertUser> = {};
-            
+
             if (updateData.profileImageUrl !== undefined) userUpdateFields.profileImageUrl = updateData.profileImageUrl;
             if (updateData.qualificationUrl !== undefined) userUpdateFields.qualificationUrl = updateData.qualificationUrl;
             if (updateData.professionalCountryCode) userUpdateFields.professionalCountryCode = updateData.professionalCountryCode;
             if (updateData.professionalPhone) userUpdateFields.professionalPhone = updateData.professionalPhone;
             if (updateData.bio !== undefined) userUpdateFields.bio = updateData.bio;
-            
+            if (updateData.spokenLanguages !== undefined) userUpdateFields.spokenLanguages = updateData.spokenLanguages;
+
             userUpdateFields.updatedAt = new Date();
 
             const updatedUser = await tx
@@ -163,6 +166,7 @@ export class InstructorRepository {
                     profileImageUrl: '/local-snow-head.png',
                     qualificationUrl: null,
                     bio: null,
+                    spokenLanguages: null,
                     updatedAt: new Date()
                 })
                 .where(eq(users.id, instructorId))
@@ -190,6 +194,7 @@ export class InstructorRepository {
                     countryCode: users.countryCode,
                     role: users.role,
                     qualificationUrl: users.qualificationUrl,
+                    spokenLanguages: users.spokenLanguages,
                     // Join data
                     sports: instructorSports.sportId,
                     resorts: instructorResorts.resortId
@@ -238,6 +243,7 @@ export class InstructorRepository {
                         countryCode: row.countryCode,
                         role: row.role,
                         qualificationUrl: row.qualificationUrl,
+                        spokenLanguages: row.spokenLanguages,
                         sports: [],
                         resorts: []
                     });

--- a/src/features/Instructors/lib/instructorSchemas.ts
+++ b/src/features/Instructors/lib/instructorSchemas.ts
@@ -56,6 +56,7 @@ export const instructorSignupSchema = z.object({
 	professionalPhone: z.string().nonempty("Insert Professional Contact Phone"),
 	bio: z.string().optional(),
 	sports: z.array(z.number()).min(1, 'Select at least one sport'),
+	spokenLanguages: z.array(z.string()).min(1, 'Select at least one language'),
 	basePrice: z.coerce.number().min(0, 'Base price must be positive'),
 	currency: z.string().min(1, 'Select currency')
 });
@@ -67,6 +68,7 @@ export const instructorProfileSchema = z.object({
 	professionalPhone: z.string().nonempty("Insert Professional Contact Phone"),
 	resort: z.coerce.number().min(1, "Choose the Resort where you teach"),
 	sports: z.array(z.number()).min(1, 'Select at least one sport'),
+	spokenLanguages: z.array(z.string()).min(1, 'Select at least one language'),
 	profileImage: imageFileSchema,
 	qualification: documentFileSchema
 });
@@ -85,6 +87,7 @@ export interface InstructorSignupData {
 	professionalPhone: string;
 	bio?: string;
 	sports: number[];
+	spokenLanguages: string[];
 	basePrice: number;
 	currency: string;
 }
@@ -95,6 +98,7 @@ export interface InstructorProfileData {
 	professionalPhone: string;
 	resort: number;
 	sports: number[];
+	spokenLanguages: string[];
 	profileImageUrl?: string | null;
 	qualificationUrl?: string | null;
 }

--- a/src/features/Instructors/lib/instructorService.ts
+++ b/src/features/Instructors/lib/instructorService.ts
@@ -61,6 +61,7 @@ export class InstructorService {
                 professionalPhone: profileData.professionalPhone,
                 resort: profileData.resort,
                 sports: profileData.sports,
+                spokenLanguages: profileData.spokenLanguages,
                 profileImageUrl: profileData.profileImageUrl,
                 qualificationUrl: profileData.qualificationUrl
             };

--- a/src/lib/components/shared/LanguageCheckboxes.svelte
+++ b/src/lib/components/shared/LanguageCheckboxes.svelte
@@ -1,0 +1,29 @@
+<script>
+	import GroupCheckboxes from "$src/lib/components/shared/GroupCheckboxes.svelte";
+
+    // Common languages spoken in ski resorts across Europe and worldwide
+    const languages = [
+        { id: 'English', label: 'English' },
+        { id: 'French', label: 'French' },
+        { id: 'German', label: 'German' },
+        { id: 'Italian', label: 'Italian' },
+        { id: 'Spanish', label: 'Spanish' },
+        { id: 'Portuguese', label: 'Portuguese' },
+        { id: 'Dutch', label: 'Dutch' },
+        { id: 'Russian', label: 'Russian' },
+        { id: 'Polish', label: 'Polish' },
+        { id: 'Czech', label: 'Czech' },
+        { id: 'Swedish', label: 'Swedish' },
+        { id: 'Norwegian', label: 'Norwegian' },
+        { id: 'Danish', label: 'Danish' },
+        { id: 'Finnish', label: 'Finnish' },
+        { id: 'Japanese', label: 'Japanese' },
+        { id: 'Chinese', label: 'Chinese' },
+        { id: 'Korean', label: 'Korean' },
+        { id: 'Arabic', label: 'Arabic' }
+    ]
+
+    let { form, name } = $props();
+</script>
+
+<GroupCheckboxes {form} {name} options={languages} legend='Languages Spoken' />

--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -31,6 +31,7 @@ export const users = pgTable('users', {
 	professionalCountryCode: varchar('professional_country_code', { length: 4}),
 	professionalPhone: varchar('professional_phone', { length: 50 }),
 	qualificationUrl: varchar('qualification_url', { length: 255 }),
+	spokenLanguages: text('spoken_languages').array(),
     isVerified: boolean('is_verified').default(false),
 	acceptedTerms: boolean('accepted_terms').notNull().default(false),
 	isSuspended: boolean('is_suspended').default(false),

--- a/src/routes/dashboard/profile/+page.server.ts
+++ b/src/routes/dashboard/profile/+page.server.ts
@@ -47,7 +47,8 @@ export const load: PageServerLoad = async (event) => {
                 professionalCountryCode: fullUser.professionalCountryCode ? parseInt(fullUser.professionalCountryCode) : 1,
                 professionalPhone: fullUser.professionalPhone || '',
                 resort: instructorData.resorts[0] || 0,
-                sports: instructorData.sports || []
+                sports: instructorData.sports || [],
+                spokenLanguages: fullUser.spokenLanguages || []
             },
             zod(instructorProfileSchema)
         );
@@ -157,6 +158,7 @@ export const actions: Actions = {
             professionalPhone: form.data.professionalPhone,
             resort: form.data.resort,
             sports: form.data.sports,
+            spokenLanguages: form.data.spokenLanguages,
             // Only update if new file was uploaded, otherwise keep existing
             profileImageUrl: profileImageUrl !== undefined ? profileImageUrl : currentUser?.profileImageUrl,
             qualificationUrl: qualificationUrl !== undefined ? qualificationUrl : currentUser?.qualificationUrl

--- a/src/routes/instructors/[id]/+page.svelte
+++ b/src/routes/instructors/[id]/+page.svelte
@@ -263,6 +263,36 @@
 						</span>
 					</div>
 				</div>
+
+				<!-- Languages Spoken -->
+				{#if instructor.spokenLanguages && instructor.spokenLanguages.length > 0}
+					<div>
+						<h2 class="title4 mb-3 flex items-center gap-2">
+							<svg
+								xmlns="http://www.w3.org/2000/svg"
+								class="size-5"
+								fill="none"
+								viewBox="0 0 24 24"
+								stroke="currentColor"
+							>
+								<path
+									stroke-linecap="round"
+									stroke-linejoin="round"
+									stroke-width="2"
+									d="M3 5h12M9 3v2m1.048 9.5A18.022 18.022 0 016.412 9m6.088 9h7M11 21l5-10 5 10M12.751 5C11.783 10.77 8.07 15.61 3 18.129"
+								/>
+							</svg>
+							Languages
+						</h2>
+						<div class="flex flex-wrap gap-2">
+							{#each instructor.spokenLanguages as language}
+								<Badge variant="outline" class="text-sm">
+									{language}
+								</Badge>
+							{/each}
+						</div>
+					</div>
+				{/if}
 			</div>
 
 			<!-- Qualifications -->


### PR DESCRIPTION
Add comprehensive language support to instructor profiles, allowing instructors to specify which languages they speak and displaying this information to potential clients.

Changes:
- Add spokenLanguages field to users table schema (text array)
- Create LanguageCheckboxes component with 18 common languages
- Update instructor signup and profile forms to include language selection
- Update Zod schemas to validate language selection (minimum 1 required)
- Update instructor service and repository to handle language data
- Display languages on instructor cards (showing up to 3 with overflow indicator)
- Display languages on instructor profile pages
- Update page server to properly load and save language preferences

Technical details:
- Languages stored as text array in PostgreSQL
- Form validation requires at least one language selection
- Language display follows existing design patterns with badges
- No instructor name search functionality (per requirements)