### PR TITLE
Restrict resort filtering to Spain only in instructor search

### DIFF
--- a/src/routes/instructors/+page.svelte
+++ b/src/routes/instructors/+page.svelte
@@ -142,7 +142,7 @@
 					<Accordion.Trigger class="text-sm font-medium">Main Filters</Accordion.Trigger>
 					<Accordion.Content class="space-y-3 pt-3">
 						<div class="grid gap-3 md:grid-cols-2 lg:grid-cols-3">
-							<SearchResort {form} name="resort" label="Resort" />
+							<SearchResort {form} name="resort" label="Resort" countryId={data.spainCountryId} />
 							<SportSelect {form} name="sport" />
 							<LanguageSelect {form} name="language" />
 						</div>


### PR DESCRIPTION
- Get Spain's country ID (countryCode='ES') in server load function
- Pass spainCountryId to SearchResort component
- Resort autocomplete now only shows Spanish resorts
- Existing z-index (z-50) already prevents dropdown clipping

This ensures instructors can only be filtered by Spanish resorts, preparing for Spain-focused launch while keeping code flexible for future country expansion.