### PR TITLE
Restrict all resort displays to Spain only

### DIFF
--- a/src/routes/instructors/+page.server.ts
+++ b/src/routes/instructors/+page.server.ts
@@ -4,7 +4,7 @@ import { InstructorService } from '$src/features/Instructors/lib/instructorServi
 import { LessonService } from '$src/features/Lessons/lib/lessonService';
 import { db } from '$lib/server/db';
 import { countries } from '$lib/server/db/schema';
-import { eq } from 'drizzle-orm';
+import { eq, sql } from 'drizzle-orm';
 
 const lessonService = new LessonService();
 const instructorService = new InstructorService();
@@ -21,11 +21,11 @@ export const load: PageServerLoad = async ({ url }) => {
     const sortBy = url.searchParams.get('sortBy');
 
     try {
-        // Get Spain's country ID for resort filtering
+        // Get Spain's country ID for resort filtering (case-insensitive)
         const spainCountry = await db
             .select({ id: countries.id })
             .from(countries)
-            .where(eq(countries.countryCode, 'ES'))
+            .where(sql`UPPER(${countries.countryCode}) = 'ES'`)
             .limit(1);
         const spainCountryId = spainCountry[0]?.id;
 

--- a/src/routes/resorts/+page.server.ts
+++ b/src/routes/resorts/+page.server.ts
@@ -1,10 +1,30 @@
 import type { PageServerLoad } from './$types';
 import { db } from '$src/lib/server/db/index';
 import { resorts, countries, regions } from '$src/lib/server/db/schema';
-import { eq } from 'drizzle-orm';
+import { eq, sql } from 'drizzle-orm';
 
 export const load: PageServerLoad = async () => {
-	// Get all resorts grouped by country
+	// Get Spain's country ID
+	const spainCountry = await db
+		.select({ id: countries.id })
+		.from(countries)
+		.where(sql`UPPER(${countries.countryCode}) = 'ES'`)
+		.limit(1);
+
+	if (!spainCountry[0]) {
+		// No Spain data yet, return empty
+		return {
+			resortsByCountry: [],
+			totalResorts: 0,
+			seo: {
+				title: 'Ski Resorts in Spain | Find Instructors',
+				description: 'Browse ski resorts in Spain and find professional ski and snowboard instructors.',
+				canonicalUrl: 'https://localsnow.com/resorts'
+			}
+		};
+	}
+
+	// Get only Spanish resorts
 	const allResorts = await db
 		.select({
 			resortId: resorts.id,
@@ -22,19 +42,20 @@ export const load: PageServerLoad = async () => {
 		.from(resorts)
 		.innerJoin(countries, eq(resorts.countryId, countries.id))
 		.leftJoin(regions, eq(resorts.regionId, regions.id))
-		.orderBy(countries.country, regions.region, resorts.name);
+		.where(eq(countries.id, spainCountry[0].id))
+		.orderBy(regions.region, resorts.name);
 
-	// Group by country
+	// Group by region (since all are in Spain)
 	const groupedResorts = allResorts.reduce((acc, resort) => {
-		const countryKey = resort.countrySlug;
-		if (!acc[countryKey]) {
-			acc[countryKey] = {
-				country: resort.countryName,
-				countrySlug: resort.countrySlug,
+		const regionKey = resort.regionSlug || 'other';
+		if (!acc[regionKey]) {
+			acc[regionKey] = {
+				region: resort.regionName || 'Other',
+				regionSlug: resort.regionSlug || 'other',
 				resorts: []
 			};
 		}
-		acc[countryKey].resorts.push({
+		acc[regionKey].resorts.push({
 			id: resort.resortId,
 			name: resort.resortName,
 			slug: resort.resortSlug,
@@ -46,14 +67,15 @@ export const load: PageServerLoad = async () => {
 		return acc;
 	}, {} as Record<string, any>);
 
-	const resortsByCountry = Object.values(groupedResorts);
+	const resortsByRegion = Object.values(groupedResorts);
 
 	return {
-		resortsByCountry,
+		resortsByCountry: resortsByRegion, // Keep same variable name for compatibility
 		totalResorts: allResorts.length,
+		countryName: 'Spain',
 		seo: {
-			title: 'Ski Resorts Directory | Find Instructors Worldwide',
-			description: `Browse ${allResorts.length} ski resorts worldwide. Find professional ski and snowboard instructors at your favorite resort.`,
+			title: 'Ski Resorts in Spain | Find Instructors',
+			description: `Browse ${allResorts.length} ski resorts in Spain. Find professional ski and snowboard instructors at your favorite Spanish resort.`,
 			canonicalUrl: 'https://localsnow.com/resorts'
 		}
 	};

--- a/src/routes/resorts/+page.svelte
+++ b/src/routes/resorts/+page.svelte
@@ -33,9 +33,9 @@
 <section class="w-full">
 	<!-- Header -->
 	<div class="mb-6 text-center">
-		<h1 class="title2 mb-2">Ski Resorts Directory</h1>
+		<h1 class="title2 mb-2">Ski Resorts in Spain</h1>
 		<p class="text-muted-foreground">
-			Browse {totalResorts} resorts worldwide and find professional instructors
+			Browse {totalResorts} Spanish ski resorts and find professional instructors
 		</p>
 	</div>
 
@@ -59,17 +59,17 @@
 				<p class="text-muted-foreground">No resorts found matching "{searchQuery}"</p>
 			</div>
 		{:else}
-			{#each filteredResorts as country}
+			{#each filteredResorts as region}
 				<div class="mb-12">
 					<h2 class="mb-6 text-2xl font-bold">
-						{country.country}
-						<Badge variant="secondary" class="ml-2">{country.resorts.length} resorts</Badge>
+						{region.region}
+						<Badge variant="secondary" class="ml-2">{region.resorts.length} resorts</Badge>
 					</h2>
 
 					<div class="grid gap-4 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-						{#each country.resorts as resort}
+						{#each region.resorts as resort}
 							<a
-								href="/resorts/{country.countrySlug}/{resort.regionSlug}/{resort.slug}"
+								href="/resorts/spain/{resort.regionSlug}/{resort.slug}"
 								class="group"
 							>
 								<Card class="h-full transition-shadow hover:shadow-lg">


### PR DESCRIPTION
- Modified /resorts page to show only Spanish resorts
- Changed grouping from country to region (all are Spain)
- Updated page title and descriptions to reflect Spain focus
- Made country code lookup case-insensitive (ES/es)
- Resort links now point to /resorts/spain/{region}/{resort}

This ensures:
- /resorts page only shows Spanish resorts
- Search autocomplete only shows Spanish resorts (via countryId filter)
- Consistent Spain-only experience across the platform