### PR TITLE
Fix: Restrict resort search to Spain on homepage and fix dropdown z-i…

### DIFF
--- a/src/features/Resorts/components/SearchResort.svelte
+++ b/src/features/Resorts/components/SearchResort.svelte
@@ -189,7 +189,7 @@
           <ul
             id="resort-listbox"
             role="listbox"
-            class="absolute top-full z-50 max-h-64 w-full overflow-auto rounded-md border border-gray-300 bg-white shadow-md"
+            class="absolute top-full z-[9999] max-h-64 w-full overflow-auto rounded-md border border-gray-300 bg-white shadow-md"
           >
             {#each suggestions as resort, i (resort.id)}
               <li

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -3,11 +3,23 @@ import { superValidate } from "sveltekit-superforms";
 import { zod } from "sveltekit-superforms/adapters";
 import { redirect, type Actions } from "@sveltejs/kit";
 import type { PageServerLoad } from "./$types";
+import { db } from '$lib/server/db';
+import { countries } from '$lib/server/db/schema';
+import { sql } from 'drizzle-orm';
 
 
 export const load: PageServerLoad = async () => {
    const form = await superValidate(zod(heroResortSearchSchema));
-   return { form }
+
+   // Get Spain's country ID for resort filtering (case-insensitive)
+   const spainCountry = await db
+       .select({ id: countries.id })
+       .from(countries)
+       .where(sql`UPPER(${countries.countryCode}) = 'ES'`)
+       .limit(1);
+   const spainCountryId = spainCountry[0]?.id;
+
+   return { form, spainCountryId }
 };
 
 export const actions: Actions = {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -114,7 +114,7 @@
 				<form method="POST" use:enhance class="mb-8 rounded-lg bg-white/90 p-4 shadow-lg">
 					<div class="flex flex-col gap-4 md:flex-row">
 						<div class="flex-1">
-							<SearchResort {form} name="resort" id="location" />
+							<SearchResort {form} name="resort" id="location" countryId={data.spainCountryId} />
 						</div>
 						<div class="text-foreground flex-1">
 							<SportSelect {form} name="sport" isHero={true} />

--- a/src/routes/instructors/+page.svelte
+++ b/src/routes/instructors/+page.svelte
@@ -111,7 +111,7 @@
 	</div>
 
 	<!-- Filters Section -->
-	<div class="mb-6 rounded-lg border border-border bg-card p-4 shadow-sm">
+	<div class="mb-6 rounded-lg border border-border bg-card p-4 shadow-sm overflow-visible">
 		<div class="mb-4 flex items-center justify-between">
 			<h2 class="text-base font-semibold">Filter & Sort Instructors</h2>
 			{#if hasActiveFilters}
@@ -135,13 +135,13 @@
 			{/if}
 		</div>
 
-		<form onsubmit={applyFilters} class="space-y-4">
-			<Accordion.Root type="multiple" value={['main', 'details']}>
+		<form onsubmit={applyFilters} class="space-y-4 overflow-visible">
+			<Accordion.Root type="multiple" value={['main', 'details']} class="overflow-visible">
 				<!-- Main Filters -->
-				<Accordion.Item value="main">
+				<Accordion.Item value="main" class="overflow-visible">
 					<Accordion.Trigger class="text-sm font-medium">Main Filters</Accordion.Trigger>
-					<Accordion.Content class="space-y-3 pt-3">
-						<div class="grid gap-3 md:grid-cols-2 lg:grid-cols-3">
+					<Accordion.Content class="space-y-3 pt-3 overflow-visible">
+						<div class="grid gap-3 md:grid-cols-2 lg:grid-cols-3 overflow-visible">
 							<SearchResort {form} name="resort" label="Resort" countryId={data.spainCountryId} />
 							<SportSelect {form} name="sport" />
 							<LanguageSelect {form} name="language" />
@@ -150,9 +150,9 @@
 				</Accordion.Item>
 
 				<!-- Advanced Filters -->
-				<Accordion.Item value="details">
+				<Accordion.Item value="details" class="overflow-visible">
 					<Accordion.Trigger class="text-sm font-medium">Advanced Filters</Accordion.Trigger>
-					<Accordion.Content class="space-y-3 pt-3">
+					<Accordion.Content class="space-y-3 pt-3 overflow-visible">
 						<!-- Price Range -->
 						<div class="grid gap-3 md:grid-cols-2">
 							<div>


### PR DESCRIPTION
…ndex

This commit addresses two remaining issues:

1. Homepage resort search now filters to Spain only
   - Added Spain country ID lookup in homepage server load function
   - Passed countryId prop to SearchResort component on homepage
   - Ensures consistent Spain-only filtering across all pages

2. Fixed dropdown visibility on instructor page
   - Increased z-index from z-50 to z-[9999] in SearchResort component
   - Added overflow-visible to accordion containers and filter section
   - Prevents dropdown from being clipped by surrounding elements
   - Especially fixes visibility issues on laptop screen sizes

All resort autocomplete inputs now show only Spanish resorts, and dropdowns are fully visible regardless of their position in accordions or other containers.