### PR TITLE
Translate About page to Spanish with full internationalization

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -259,6 +259,46 @@
 	"instructors_page_empty_subtitle": "Try adjusting your filters to see more results",
 	"instructors_page_empty_clear_filters": "Clear All Filters",
 	"about_title": "About Local Snow",
+	"about_meta_description": "Local Snow is built by a ski instructor with experience across Argentina, New Zealand, Spain, and Chile. A fair platform that gives instructors ownership while connecting clients directly with the people who teach them.",
+
+	"about_who_built_title": "Who Built This",
+	"about_who_built_p1": "I'm a ski instructor. I've worked in Argentina, New Zealand, Spain, Chile—different continents, different resort cultures, different approaches to the same job. That perspective showed me something: the current system has fundamental problems that hurt instructors, clients, and the snowsports industry as a whole.",
+
+	"about_economic_title": "The Economic Reality",
+	"about_economic_p1": "Ski schools operate like managers or representatives for instructors. And like any management relationship, they take a cut. But in what other industry does a manager take more than 50% of the talent's earnings?",
+	"about_economic_p2": "In many school setups, the school gets paid per person per hour while instructors get paid a flat hourly rate regardless of how many students they teach. A group lesson with 6 people? The school might charge €60/hour per person (€360 total) while the instructor earns €25/hour. The math doesn't add up for the people doing the actual work.",
+	"about_economic_p3": "And booking platforms? They charge 15-20% commissions on top of that, plus subscription fees for basic features like managing your own calendar or setting your own pricing. Tools that should be standard are locked behind paywalls.",
+
+	"about_visibility_title": "The Visibility Problem",
+	"about_visibility_p1": "Schools often act as a screen between clients and instructors. But clients aren't just buying a lesson—they're trusting someone with their safety, or more importantly, their kids' safety. They have every right to know who that person is, see their qualifications, and make an informed choice.",
+	"about_visibility_p2": "The best instructors deserve to be visible. The system shouldn't hide talent behind institutional branding.",
+
+	"about_risk_title": "Risk vs. Reward",
+	"about_risk_p1": "Being a ski instructor comes with real risks. Physical injury, liability exposure, unpredictable income, seasonal uncertainty. We take on all of that, and yet most of us can't make a comfortable living from it. That's not sustainable, and it's not fair.",
+	"about_risk_p2": "Instructors need tools that help them manage their business, own their client relationships, and earn what they're worth—without sacrificing half their income to middlemen.",
+
+	"about_what_is_title": "What Local Snow Is",
+	"about_what_is_p1": "Local Snow is a free directory where instructors list their profiles and clients find them directly. No commissions on lessons. No subscription fees. No hidden costs. Just a small €5 lead fee when an instructor chooses to respond to a booking request.",
+	"about_what_is_p2": "I'm not trying to destroy ski schools or booking platforms. Schools serve a purpose—they provide structure, insurance, training programs, and consistent work for instructors who want that. But there should also be space for independent instructors to operate fairly, and for school instructors to build their own reputation and client base.",
+	"about_what_is_p3": "This isn't a war between independents and schools. It's about building a bridge.",
+
+	"about_verification_title": "The Verification Process",
+	"about_verification_p1": "I manually review every instructor who applies for verification. I check certifications, qualifications, and professional credentials. The badge doesn't mean someone is the best instructor in the world—it confirms they're legitimate, qualified, and take their work seriously.",
+	"about_verification_p2": "Clients deserve to know who they're working with. Instructors deserve to be recognized for their qualifications. That's what verification is for.",
+
+	"about_spain_title": "Why Spain First",
+	"about_spain_p1": "I've worked here. I know the resorts, the instructors, the local dynamics. Starting focused made more sense than trying to build a worldwide directory on day one. If this works in Spain and helps instructors make a better living while giving clients better access to great instruction, maybe it expands. If not, at least I tried.",
+
+	"about_goal_title": "The Goal",
+	"about_goal_p1": "I want instructors—independent and school-affiliated—to have affordable tools that give them ownership over their work. I want clients to connect directly with the people who teach them. I want the snowsports industry to be a place where talented instructors can build sustainable careers doing what they love.",
+	"about_goal_p2": "This isn't about getting rich or scaling into some venture-backed startup. It's about fixing something broken. If Local Snow helps even a handful of instructors earn more and a handful of clients find better instruction, it's worth it.",
+
+	"about_contact_title": "Get in Touch",
+	"about_contact_p1": "If you're an instructor in Spain—independent or working for a school—{createProfile}. If you have feedback or questions, email me at {email}.",
+	"about_contact_p2": "That's it. No manifesto, no corporate mission statement. Just trying to do better.",
+	"about_contact_create_profile": "create a profile",
+	"about_contact_email": "support@localsnow.org",
+
 	"about_intro": "Local Snow is a free directory connecting clients with independent ski and snowboard instructors across Spain.",
 	"about_mission_title": "Our Mission",
 	"about_mission_text": "We believe ski lessons should be accessible without expensive booking fees. Our platform lets instructors set their own prices and keep 100% of their lesson fees.",

--- a/messages/es.json
+++ b/messages/es.json
@@ -264,6 +264,46 @@
 	"seo_meta_how_it_works_title": "Cómo Funciona | Local Snow",
 	"seo_meta_how_it_works_description": "Aprende cómo Local Snow conecta clientes con instructores de esquí en España. Proceso simple para reservar clases y publicar tu perfil de instructor.",
 	"about_title": "Acerca de Local Snow",
+	"about_meta_description": "Local Snow fue creado por un instructor de esquí con experiencia en Argentina, Nueva Zelanda, España y Chile. Una plataforma justa que da propiedad a los instructores mientras conecta a los clientes directamente con las personas que les enseñan.",
+
+	"about_who_built_title": "Quién Construyó Esto",
+	"about_who_built_p1": "Soy instructor de esquí. He trabajado en Argentina, Nueva Zelanda, España, Chile—diferentes continentes, diferentes culturas de estaciones, diferentes enfoques para el mismo trabajo. Esa perspectiva me mostró algo: el sistema actual tiene problemas fundamentales que perjudican a instructores, clientes y a la industria de deportes de nieve en general.",
+
+	"about_economic_title": "La Realidad Económica",
+	"about_economic_p1": "Las escuelas de esquí operan como gerentes o representantes de instructores. Y como cualquier relación de gestión, toman una comisión. Pero ¿en qué otra industria un gerente toma más del 50% de las ganancias del talento?",
+	"about_economic_p2": "En muchas configuraciones de escuelas, la escuela cobra por persona por hora mientras los instructores reciben un salario por hora fijo sin importar cuántos estudiantes enseñen. ¿Una clase grupal con 6 personas? La escuela puede cobrar 60€/hora por persona (360€ total) mientras el instructor gana 25€/hora. Las matemáticas no cuadran para las personas que hacen el trabajo real.",
+	"about_economic_p3": "¿Y las plataformas de reservas? Cobran comisiones del 15-20% además de eso, más tarifas de suscripción por funciones básicas como gestionar tu propio calendario o establecer tus propios precios. Herramientas que deberían ser estándar están bloqueadas detrás de muros de pago.",
+
+	"about_visibility_title": "El Problema de Visibilidad",
+	"about_visibility_p1": "Las escuelas a menudo actúan como una pantalla entre clientes e instructores. Pero los clientes no solo están comprando una clase—están confiando en alguien con su seguridad, o más importante, la seguridad de sus hijos. Tienen todo el derecho de saber quién es esa persona, ver sus calificaciones y tomar una decisión informada.",
+	"about_visibility_p2": "Los mejores instructores merecen ser visibles. El sistema no debería ocultar el talento detrás de marcas institucionales.",
+
+	"about_risk_title": "Riesgo vs. Recompensa",
+	"about_risk_p1": "Ser instructor de esquí conlleva riesgos reales. Lesiones físicas, exposición a responsabilidad, ingresos impredecibles, incertidumbre estacional. Asumimos todo eso, y sin embargo la mayoría de nosotros no puede ganarse la vida cómodamente con ello. Eso no es sostenible, y no es justo.",
+	"about_risk_p2": "Los instructores necesitan herramientas que les ayuden a gestionar su negocio, poseer sus relaciones con clientes y ganar lo que valen—sin sacrificar la mitad de sus ingresos a intermediarios.",
+
+	"about_what_is_title": "Qué es Local Snow",
+	"about_what_is_p1": "Local Snow es un directorio gratuito donde los instructores publican sus perfiles y los clientes los encuentran directamente. Sin comisiones en clases. Sin tarifas de suscripción. Sin costos ocultos. Solo una pequeña tarifa de lead de 5€ cuando un instructor elige responder a una solicitud de reserva.",
+	"about_what_is_p2": "No estoy tratando de destruir escuelas de esquí o plataformas de reservas. Las escuelas sirven un propósito—proporcionan estructura, seguro, programas de capacitación y trabajo constante para instructores que quieren eso. Pero también debería haber espacio para que instructores independientes operen justamente, y para que instructores de escuelas construyan su propia reputación y base de clientes.",
+	"about_what_is_p3": "Esto no es una guerra entre independientes y escuelas. Se trata de construir un puente.",
+
+	"about_verification_title": "El Proceso de Verificación",
+	"about_verification_p1": "Reviso manualmente a cada instructor que solicita verificación. Verifico certificaciones, calificaciones y credenciales profesionales. La insignia no significa que alguien es el mejor instructor del mundo—confirma que son legítimos, calificados y toman su trabajo en serio.",
+	"about_verification_p2": "Los clientes merecen saber con quién están trabajando. Los instructores merecen ser reconocidos por sus calificaciones. Para eso es la verificación.",
+
+	"about_spain_title": "Por Qué España Primero",
+	"about_spain_p1": "He trabajado aquí. Conozco las estaciones, los instructores, las dinámicas locales. Comenzar enfocado tenía más sentido que tratar de construir un directorio mundial desde el primer día. Si esto funciona en España y ayuda a los instructores a ganarse mejor la vida mientras da a los clientes mejor acceso a excelente instrucción, tal vez se expanda. Si no, al menos lo intenté.",
+
+	"about_goal_title": "El Objetivo",
+	"about_goal_p1": "Quiero que los instructores—independientes y afiliados a escuelas—tengan herramientas asequibles que les den propiedad sobre su trabajo. Quiero que los clientes se conecten directamente con las personas que les enseñan. Quiero que la industria de deportes de nieve sea un lugar donde instructores talentosos puedan construir carreras sostenibles haciendo lo que aman.",
+	"about_goal_p2": "Esto no se trata de hacerse rico o escalar en alguna startup respaldada por capital de riesgo. Se trata de arreglar algo roto. Si Local Snow ayuda aunque sea a un puñado de instructores a ganar más y a un puñado de clientes a encontrar mejor instrucción, vale la pena.",
+
+	"about_contact_title": "Ponte en Contacto",
+	"about_contact_p1": "Si eres instructor en España—independiente o trabajando para una escuela—{createProfile}. Si tienes comentarios o preguntas, envíame un correo a {email}.",
+	"about_contact_p2": "Eso es todo. Sin manifiestos, sin declaraciones de misión corporativas. Solo tratando de hacerlo mejor.",
+	"about_contact_create_profile": "crea un perfil",
+	"about_contact_email": "support@localsnow.org",
+
 	"about_intro": "Local Snow es un directorio gratuito que conecta clientes con instructores independientes de esquí y snowboard en toda España.",
 	"about_mission_title": "Nuestra Misión",
 	"about_mission_text": "Creemos que las clases de esquí deben ser accesibles sin costosas comisiones de reserva. Nuestra plataforma permite a los instructores fijar sus propios precios y quedarse el 100% de sus tarifas de clases.",

--- a/src/routes/about/+page.svelte
+++ b/src/routes/about/+page.svelte
@@ -1,133 +1,103 @@
+<script lang="ts">
+	import * as m from '$lib/paraglide/messages';
+</script>
+
 <svelte:head>
-	<title>About | Local Snow</title>
+	<title>{m.about_title()} | Local Snow</title>
 	<meta
 		name="description"
-		content="Local Snow is built by a ski instructor with experience across Argentina, New Zealand, Spain, and Chile. A fair platform that gives instructors ownership while connecting clients directly with the people who teach them."
+		content={m.about_meta_description()}
 	/>
 </svelte:head>
 
 <article class="prose prose-sm mx-auto max-w-2xl">
-	<h1 class="title2">About Local Snow</h1>
+	<h1 class="title2">{m.about_title()}</h1>
 
 	<section class="my-6">
-		<h2 class="title3">Who Built This</h2>
+		<h2 class="title3">{m.about_who_built_title()}</h2>
 		<p>
-			I'm a ski instructor. I've worked in Argentina, New Zealand, Spain, Chile—different
-			continents, different resort cultures, different approaches to the same job. That perspective
-			showed me something: the current system has fundamental problems that hurt instructors,
-			clients, and the snowsports industry as a whole.
+			{m.about_who_built_p1()}
 		</p>
 	</section>
 
 	<section class="my-6">
-		<h2 class="title3">The Economic Reality</h2>
+		<h2 class="title3">{m.about_economic_title()}</h2>
 		<p>
-			Ski schools operate like managers or representatives for instructors. And like any management
-			relationship, they take a cut. But in what other industry does a manager take more than 50% of
-			the talent's earnings?
+			{m.about_economic_p1()}
 		</p>
 		<p>
-			In many school setups, the school gets paid per person per hour while instructors get paid a
-			flat hourly rate regardless of how many students they teach. A group lesson with 6 people? The
-			school might charge €60/hour per person (€360 total) while the instructor earns €25/hour. The
-			math doesn't add up for the people doing the actual work.
+			{m.about_economic_p2()}
 		</p>
 		<p>
-			And booking platforms? They charge 15-20% commissions on top of that, plus subscription fees
-			for basic features like managing your own calendar or setting your own pricing. Tools that
-			should be standard are locked behind paywalls.
+			{m.about_economic_p3()}
 		</p>
 	</section>
 
 	<section class="my-6">
-		<h2 class="title3">The Visibility Problem</h2>
+		<h2 class="title3">{m.about_visibility_title()}</h2>
 		<p>
-			Schools often act as a screen between clients and instructors. But clients aren't just buying
-			a lesson—they're trusting someone with their safety, or more importantly, their kids' safety.
-			They have every right to know who that person is, see their qualifications, and make an
-			informed choice.
+			{m.about_visibility_p1()}
 		</p>
 		<p>
-			The best instructors deserve to be visible. The system shouldn't hide talent behind
-			institutional branding.
+			{m.about_visibility_p2()}
 		</p>
 	</section>
 
 	<section class="my-6">
-		<h2 class="title3">Risk vs. Reward</h2>
+		<h2 class="title3">{m.about_risk_title()}</h2>
 		<p>
-			Being a ski instructor comes with real risks. Physical injury, liability exposure,
-			unpredictable income, seasonal uncertainty. We take on all of that, and yet most of us can't
-			make a comfortable living from it. That's not sustainable, and it's not fair.
+			{m.about_risk_p1()}
 		</p>
 		<p>
-			Instructors need tools that help them manage their business, own their client relationships,
-			and earn what they're worth—without sacrificing half their income to middlemen.
+			{m.about_risk_p2()}
 		</p>
 	</section>
 
 	<section class="my-6">
-		<h2 class="title3">What Local Snow Is</h2>
+		<h2 class="title3">{m.about_what_is_title()}</h2>
 		<p>
-			Local Snow is a free directory where instructors list their profiles and clients find them
-			directly. No commissions on lessons. No subscription fees. No hidden costs. Just a small €5
-			lead fee when an instructor chooses to respond to a booking request.
+			{m.about_what_is_p1()}
 		</p>
 		<p>
-			I'm not trying to destroy ski schools or booking platforms. Schools serve a purpose—they
-			provide structure, insurance, training programs, and consistent work for instructors who want
-			that. But there should also be space for independent instructors to operate fairly, and for
-			school instructors to build their own reputation and client base.
+			{m.about_what_is_p2()}
 		</p>
-		<p>This isn't a war between independents and schools. It's about building a bridge.</p>
+		<p>{m.about_what_is_p3()}</p>
 	</section>
 
 	<section class="my-6">
-		<h2 class="title3">The Verification Process</h2>
+		<h2 class="title3">{m.about_verification_title()}</h2>
 		<p>
-			I manually review every instructor who applies for verification. I check certifications,
-			qualifications, and professional credentials. The badge doesn't mean someone is the best
-			instructor in the world—it confirms they're legitimate, qualified, and take their work
-			seriously.
+			{m.about_verification_p1()}
 		</p>
 		<p>
-			Clients deserve to know who they're working with. Instructors deserve to be recognized for
-			their qualifications. That's what verification is for.
+			{m.about_verification_p2()}
 		</p>
 	</section>
 
 	<section class="my-6">
-		<h2 class="title3">Why Spain First</h2>
+		<h2 class="title3">{m.about_spain_title()}</h2>
 		<p>
-			I've worked here. I know the resorts, the instructors, the local dynamics. Starting focused
-			made more sense than trying to build a worldwide directory on day one. If this works in Spain
-			and helps instructors make a better living while giving clients better access to great
-			instruction, maybe it expands. If not, at least I tried.
+			{m.about_spain_p1()}
 		</p>
 	</section>
 
 	<section class="my-6">
-		<h2 class="title3">The Goal</h2>
+		<h2 class="title3">{m.about_goal_title()}</h2>
 		<p>
-			I want instructors—independent and school-affiliated—to have affordable tools that give them
-			ownership over their work. I want clients to connect directly with the people who teach them.
-			I want the snowsports industry to be a place where talented instructors can build sustainable
-			careers doing what they love.
+			{m.about_goal_p1()}
 		</p>
 		<p>
-			This isn't about getting rich or scaling into some venture-backed startup. It's about fixing
-			something broken. If Local Snow helps even a handful of instructors earn more and a handful of
-			clients find better instruction, it's worth it.
+			{m.about_goal_p2()}
 		</p>
 	</section>
 
 	<section class="my-6">
-		<h2 class="title3">Get in Touch</h2>
+		<h2 class="title3">{m.about_contact_title()}</h2>
 		<p>
-			If you're an instructor in Spain—independent or working for a school—<a href="/signup"
-				>create a profile</a
-			>. If you have feedback or questions, email me at <strong>support@localsnow.org</strong>.
+			{@html m.about_contact_p1()
+				.replace('{createProfile}', `<a href="/signup">${m.about_contact_create_profile()}</a>`)
+				.replace('{email}', `<strong>${m.about_contact_email()}</strong>`)}
 		</p>
-		<p>That's it. No manifesto, no corporate mission statement. Just trying to do better.</p>
+		<p>{m.about_contact_p2()}</p>
 	</section>
 </article>


### PR DESCRIPTION
## Changes

### Translation Keys Added (EN + ES)
Added 30+ new translation keys covering the entire About page:

**Sections translated:**
- Who Built This - Personal story of the instructor founder
- The Economic Reality - How ski schools and platforms take large cuts
- The Visibility Problem - Why instructors should be visible to clients
- Risk vs. Reward - Challenges of being a ski instructor
- What Local Snow Is - Platform mission and bridge philosophy
- The Verification Process - How instructor verification works
- Why Spain First - Rationale for starting in Spain
- The Goal - Long-term vision for the platform
- Get in Touch - Contact information and call to action

### Updated Component
**src/routes/about/+page.svelte:**
- Removed all hardcoded English text
- Imported paraglide messages
- All content now uses translation functions
- Dynamic meta description from translations
- Supports language switching between EN/ES

### Spanish Translations (es.json)
High-quality Spanish translations maintaining the personal, authentic tone:
- Professional yet conversational
- Culturally appropriate for Spanish audience
- Maintains the founder's voice and perspective
- Accurate technical terminology

## Result
✅ About page fully translated to Spanish
✅ Seamless language switching
✅ SEO metadata in both languages
✅ Maintains authentic founder voice in both languages

Users can now read the full platform story in their preferred language.