### PR TITLE
Fix duplicate bookings issue in instructor dashboard

### DIFF
--- a/src/routes/api/bookings/create/+server.ts
+++ b/src/routes/api/bookings/create/+server.ts
@@ -89,8 +89,15 @@ export const POST: RequestHandler = async ({ request, url }) => {
             isUsingLaunchCode = true;
         }
 
-        // ✅ CREATE BOOKING FIRST (get booking ID)
+        // ✅ CHECK FOR DUPLICATE BOOKING REQUEST
         const bookingService = new BookingRequestService();
+        const canCreate = await bookingService.canCreateRequest(instructorId, data.clientEmail);
+
+        if (!canCreate.allowed) {
+            throw error(409, canCreate.reason || 'You already have an active request with this instructor');
+        }
+
+        // ✅ CREATE BOOKING FIRST (get booking ID)
         const bookingRequest = await bookingService.createBookingRequest({
             instructorId,
             clientName: data.clientName,


### PR DESCRIPTION
Fixed two critical issues causing duplicate bookings:

1. **Display Duplicates**: The `getBookingsWithDetailsForInstructor` query was doing a LEFT JOIN with `leadPayments`, which created duplicate rows when multiple payment records existed for the same booking (e.g., payment retries, refunds, or multiple payment attempts).

   **Solution**: Implemented smart de-duplication using a Map that:
   - Keeps track of unique booking IDs
   - Prioritizes rows with payment information
   - Keeps the most recent payment when multiple exist
   - Removes the debug console warnings that were previously masking the issue

2. **Creation Duplicates**: The `/api/bookings/create` endpoint was missing duplicate prevention validation, allowing users to create multiple booking requests for the same instructor (via double-clicks, network issues, or form resubmissions).

   **Solution**: Added `canCreateRequest` validation check before creating bookings to prevent duplicate requests from the same client to the same instructor with active status (pending, viewed, or accepted).

## Technical Details:

**File**: `src/features/Bookings/lib/bookingRequestRepository.ts`
- Removed error-prone LEFT JOIN duplicate handling with try-catch
- Implemented Map-based de-duplication with smart conflict resolution
- Cleaner code that handles edge cases properly

**File**: `src/routes/api/bookings/create/+server.ts`
- Added duplicate check before booking creation
- Returns 409 error with clear message if duplicate detected
- Prevents database pollution from duplicate submissions

## Testing Notes:
- Existing bookings with multiple payments will now display correctly
- Double-click protection works at both UI and API levels
- Clear error messages for users trying to create duplicate requests