### PR TITLE
Fix launch code usage increment - use sql from drizzle-orm

### DIFF
--- a/src/features/LaunchCodes/lib/launchCodeRepository.ts
+++ b/src/features/LaunchCodes/lib/launchCodeRepository.ts
@@ -1,6 +1,6 @@
 import { db } from "$lib/server/db";
 import { launchCodes } from "$lib/server/db/schema";
-import { eq, and } from "drizzle-orm";
+import { eq, and, sql } from "drizzle-orm";
 
 /**
  * Repository for launch codes data access
@@ -43,7 +43,7 @@ export class LaunchCodeRepository {
         await db
             .update(launchCodes)
             .set({
-                currentUses: db.$sql`${launchCodes.currentUses} + 1`
+                currentUses: sql`${launchCodes.currentUses} + 1`
             })
             .where(eq(launchCodes.id, codeId));
     }


### PR DESCRIPTION
- Import sql from drizzle-orm
- Change db.$sql to sql in incrementUsage method
- Fixes TypeError: db.$sql is not a function