### PR TITLE
Add requested time slots display to instructor booking detail dialog

### DIFF
--- a/src/features/Bookings/components/BookingDetailDialog.svelte
+++ b/src/features/Bookings/components/BookingDetailDialog.svelte
@@ -66,6 +66,21 @@
 			isLoadingDeposit = false;
 		}
 	}
+
+	// Parse time slots from JSON string
+	const formatTimeSlots = (timeSlots: string) => {
+		try {
+			const slots = JSON.parse(timeSlots);
+			if (Array.isArray(slots)) {
+				return slots;
+			}
+			return [];
+		} catch {
+			return [];
+		}
+	};
+
+	const timeSlots = $derived(formatTimeSlots(booking.timeSlots || '[]'));
 </script>
 
 <Dialog.Root bind:open>
@@ -256,6 +271,19 @@
 						</div>
 					</div>
 				</div>
+
+				{#if timeSlots.length > 0}
+					<div class="mt-4">
+						<span class="text-muted-foreground text-sm">Requested Time Slots:</span>
+						<div class="mt-2 flex flex-wrap gap-2">
+							{#each timeSlots as slot}
+								<Badge variant="secondary" class="text-sm">
+									{slot}
+								</Badge>
+							{/each}
+						</div>
+					</div>
+				{/if}
 			</div>
 
 			<!-- Price Estimate -->


### PR DESCRIPTION
Instructors can now see the specific time slots requested by clients in the booking detail dialog, making it easier to understand the booking requirements, especially for multi-day bookings.

Changes:
- Added formatTimeSlots() function to parse JSON time slots
- Added time slots display section in the Lesson Details area
- Shows time slots as badges for easy readability
- Only displays when time slots are available

Display:
- Located after the Sports field in Lesson Details
- Each time slot shown as a secondary badge (e.g., "09:00-10:00")
- Responsive flex layout for multiple time slots
- Consistent with client booking detail page design

Benefits:
- Instructors can see exact time preferences
- Better understanding of multi-day booking patterns
- Helps instructors make informed accept/reject decisions
- Reduces confusion about lesson timing