### PR TITLE
Replace hardcoded string with translation key in BookingDetailDialog

### DIFF
--- a/src/features/Bookings/components/BookingDetailDialog.svelte
+++ b/src/features/Bookings/components/BookingDetailDialog.svelte
@@ -274,7 +274,7 @@
 
 				{#if timeSlots.length > 0}
 					<div class="mt-4">
-						<span class="text-muted-foreground text-sm">Requested Time Slots:</span>
+						<span class="text-muted-foreground text-sm">{m.client_requested_times()}</span>
 						<div class="mt-2 flex flex-wrap gap-2">
 							{#each timeSlots as slot}
 								<Badge variant="secondary" class="text-sm">


### PR DESCRIPTION
Fixed hardcoded "Requested Time Slots:" string to use the existing translation key m.client_requested_times() for proper internationalization.

Changes:
- src/features/Bookings/components/BookingDetailDialog.svelte:277
  * Changed: "Requested Time Slots:" → {m.client_requested_times()}

Translations (already exist):
- English: "Requested Time Slots"
- Spanish: "Horarios Solicitados"

This ensures the instructor booking detail dialog is properly internationalized and displays in the user's selected language.