### PR TITLE
Add time slots and created timestamp to booking detail views

### DIFF
--- a/src/features/Bookings/components/BookingDetailDialog.svelte
+++ b/src/features/Bookings/components/BookingDetailDialog.svelte
@@ -95,6 +95,11 @@
 			<Dialog.Description>
 				Review the booking details and take action
 			</Dialog.Description>
+			{#if booking.createdAt}
+				<p class="text-xs text-muted-foreground mt-2">
+					Created: {new Date(booking.createdAt).toLocaleString()}
+				</p>
+			{/if}
 		</Dialog.Header>
 
 		<div class="space-y-6 py-4">

--- a/src/features/Bookings/lib/bookingRequestRepository.ts
+++ b/src/features/Bookings/lib/bookingRequestRepository.ts
@@ -99,6 +99,7 @@ export class BookingRequestRepository {
                 startDate: bookingRequests.startDate,
                 endDate: bookingRequests.endDate,
                 hoursPerDay: bookingRequests.hoursPerDay,
+                timeSlots: bookingRequests.timeSlots,
                 skillLevel: bookingRequests.skillLevel,
                 message: bookingRequests.message,
                 estimatedPrice: bookingRequests.estimatedPrice,

--- a/src/routes/dashboard/my-bookings/[id]/+page.svelte
+++ b/src/routes/dashboard/my-bookings/[id]/+page.svelte
@@ -52,6 +52,9 @@
 				<p class="text-muted-foreground">
 					{m.client_created_on({ date: new Date(booking.createdAt).toLocaleDateString() })}
 				</p>
+				<p class="text-xs text-muted-foreground mt-1">
+					{new Date(booking.createdAt).toLocaleString()}
+				</p>
 			</div>
 			<Badge variant={statusConfig.variant} class={statusConfig.class}>
 				{statusConfig.label}


### PR DESCRIPTION
This commit fixes two issues and adds helpful tracking information:

1. Instructor time slots display was missing due to missing field in query
2. Added "created at" timestamp to both instructor and client views

## Problem 1: Time Slots Not Showing for Instructors The instructor booking detail dialog wasn't showing requested time slots even though the display logic was added, because the database query was missing the timeSlots field.

## Problem 2: No Creation Timestamp Visible
Both instructors and clients couldn't see when a booking request was created, which is useful for tracking and debugging.

## Changes:

### Instructor Query Fix
- src/features/Bookings/lib/bookingRequestRepository.ts:102
  * Added timeSlots field to getBookingsWithDetailsForInstructor query
  * Now instructors can see requested time slots in booking dialog

### Instructor Dialog Timestamp
- src/features/Bookings/components/BookingDetailDialog.svelte:98-102
  * Added "Created: [date/time]" below dialog description
  * Uses browser's locale format for consistent display
  * Shown in Dialog.Description area for easy visibility

### Client Page Timestamp
- src/routes/dashboard/my-bookings/[id]/+page.svelte:55-57
  * Added full timestamp below existing date display
  * Shows both date (already there) and full datetime
  * Format: "12/20/2024, 3:45:30 PM" (locale-aware)

## Display Format:
- **Instructor dialog**: "Created: 12/20/2024, 3:45:30 PM"
- **Client page**: Shows date on one line, full datetime below

## Benefits:
- ✅ Instructors can now see requested time slots
- ✅ Both parties can track when booking was created
- ✅ Helpful for support and debugging
- ✅ Transparent for users
- ✅ Uses locale-aware formatting