### PR TITLE
Fix about page translation parameter error

### DIFF
--- a/src/routes/about/+page.svelte
+++ b/src/routes/about/+page.svelte
@@ -94,9 +94,10 @@
 	<section class="my-6">
 		<h2 class="title3">{m.about_contact_title()}</h2>
 		<p>
-			{@html m.about_contact_p1()
-				.replace('{createProfile}', `<a href="/signup">${m.about_contact_create_profile()}</a>`)
-				.replace('{email}', `<strong>${m.about_contact_email()}</strong>`)}
+			{@html m.about_contact_p1({
+				createProfile: `<a href="/signup">${m.about_contact_create_profile()}</a>`,
+				email: `<strong>${m.about_contact_email()}</strong>`
+			})}
 		</p>
 		<p>{m.about_contact_p2()}</p>
 	</section>


### PR DESCRIPTION
Fixed TypeError in about_contact_p1 translation by passing parameters as an object instead of using string replace. Paraglide i18n expects parameterized translations to receive their values as function arguments, not through post-processing with .replace().

Changed from:
  m.about_contact_p1().replace('{createProfile}', ...).replace('{email}', ...)

To:
  m.about_contact_p1({ createProfile: ..., email: ... })

This resolves the "Cannot read properties of undefined (reading 'createProfile')" error.