### PR TITLE
Fix: Escape dollar signs in healthcheck command for Docker Swarm

### DIFF
--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -103,7 +103,7 @@ services:
           memory: 512M
           cpus: '0.5'
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U $(cat /run/secrets/localsnow_postgres_user) -d $(cat /run/secrets/localsnow_postgres_db)"]
+      test: ["CMD-SHELL", "pg_isready -U $$(cat /run/secrets/localsnow_postgres_user) -d $$(cat /run/secrets/localsnow_postgres_db)"]
       interval: 10s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
Docker Swarm requires $ to be escaped as 522 in interpolated strings. Fixed postgres healthcheck to use 522 instead of $.