### PR TITLE
Fix: Increase Node.js heap size to resolve Docker build memory error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,8 @@ COPY . .
 COPY .env.build .env
 
 # Export all vars from .env file and build
+# Increase Node.js memory limit to prevent heap out of memory errors during build
+ENV NODE_OPTIONS="--max-old-space-size=4096"
 RUN export $(cat .env | xargs) && pnpm run build
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
Added NODE_OPTIONS with --max-old-space-size=4096 to the builder stage to prevent 'JavaScript heap out of memory' errors during Vite build.