### PR TITLE
Fix: Docker Swarm deployment crashes due to health check and SSL issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -74,8 +74,8 @@ USER sveltekit
 EXPOSE 3000
 
 # Health check
-HEALTHCHECK --interval=30s --timeout=3s --start-period=90s --retries=3 \
-    CMD node -e "require('http').get('http://localhost:3000/', (r) => {process.exit(r.statusCode === 200 ? 0 : 1)})"
+HEALTHCHECK --interval=30s --timeout=10s --start-period=90s --retries=3 \
+    CMD node -e "require('http').get('http://localhost:3000/api/health', (r) => {let body='';r.on('data', (d) => body+=d);r.on('end', () => {const ok=r.statusCode===200;process.exit(ok?0:1);});}).on('error', () => process.exit(1))"
 
 # Set environment to production
 ENV NODE_ENV=production

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -228,7 +228,7 @@ services:
 
     # Health check for the application
     healthcheck:
-      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:3000/api/health"]
+      test: ["CMD", "node", "-e", "require('http').get('http://localhost:3000/api/health', (r) => {let body='';r.on('data', (d) => body+=d);r.on('end', () => {const ok=r.statusCode===200;process.exit(ok?0:1);});}).on('error', () => process.exit(1))"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/src/lib/server/db/index.ts
+++ b/src/lib/server/db/index.ts
@@ -12,9 +12,17 @@ if (!DATABASE_URL) {
   throw new Error('DATABASE_URL is not set');
 }
 
+// Check if we should use SSL based on DATABASE_URL
+// If URL contains sslmode=require or uses a cloud provider, use SSL
+// For local development and Docker Swarm deployments without SSL, disable it
+const shouldUseSSL = DATABASE_URL.includes('sslmode=require') ||
+                     DATABASE_URL.includes('amazonaws.com') ||
+                     DATABASE_URL.includes('supabase.co') ||
+                     DATABASE_URL.includes('neon.tech');
+
 const pool = new Pool({
   connectionString: DATABASE_URL,
-  ssl: NODE_ENV === 'production' ? { rejectUnauthorized: true } : false,
+  ssl: shouldUseSSL ? { rejectUnauthorized: true } : false,
   max: PGPOOLSIZE ? Number(process.env.PGPOOLSIZE) : 10
 });
 


### PR DESCRIPTION
Root causes identified and fixed:
1. Health checks using wget (not available in alpine image)
2. Database SSL enforced in production without SSL-enabled postgres
3. Health check pointing to wrong endpoint (/ instead of /api/health)

Changes:
- Updated database SSL logic to detect cloud providers vs local deployments
- Fixed docker-compose health check to use node HTTP instead of wget
- Fixed Dockerfile health check to test /api/health endpoint
- Increased health check timeout to 10s for reliability

This resolves the containers starting then immediately shutting down issue.