### PR TITLE
Fix: Add ORIGIN and proxy headers for SvelteKit adapter-node

### DIFF
--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -135,6 +135,9 @@ services:
       # Non-secret configuration
       NODE_ENV: production
       PROJECT_URL: https://localsnow.org
+      ORIGIN: https://localsnow.org
+      PROTOCOL_HEADER: x-forwarded-proto
+      HOST_HEADER: x-forwarded-host
 
       # Point to Docker secret files
       # Our config.ts reads these _FILE env vars and loads the secret files


### PR DESCRIPTION
SvelteKit's adapter-node needs explicit ORIGIN configuration when behind a reverse proxy (Traefik). This fixes the 500 error and ensures the app correctly detects the domain from X-Forwarded-* headers.

Changes:
- Add ORIGIN environment variable (https://localsnow.org)
- Add PROTOCOL_HEADER to detect HTTPS from x-forwarded-proto
- Add HOST_HEADER to detect host from x-forwarded-host

This resolves the 500 Internal Error and incorrect localhost:3000 URLs.