### PR TITLE
Tone down 'free forever' messaging and add booking accept functionality

### DIFF
--- a/src/features/Bookings/components/BookingDetailDialog.svelte
+++ b/src/features/Bookings/components/BookingDetailDialog.svelte
@@ -270,16 +270,46 @@
 						<span class="font-semibold">Next Steps</span>
 					</div>
 					<p class="text-sm text-blue-700 mb-3">
-						Review the booking details and contact the client directly using the information above. If you're not interested, you can reject this request.
+						Review the booking details and contact the client directly using the information above. You can accept this request to confirm your availability, or reject it if you're not interested.
 					</p>
-					<Button
-						variant="outline"
-						class="w-full"
-						onclick={() => showRejectConfirm = true}
-						disabled={isSubmitting}
-					>
-						Not Interested - Reject Request
-					</Button>
+					<div class="flex gap-3">
+						<form
+							method="POST"
+							action="?/acceptBooking"
+							class="flex-1"
+							use:enhance={() => {
+								isSubmitting = true;
+								return async ({ result, update }) => {
+									isSubmitting = false;
+									if (result.type === 'success') {
+										actionResult = { success: true, message: 'Booking accepted! The client has been notified.' };
+										setTimeout(() => {
+											open = false;
+											window.location.reload();
+										}, 1500);
+									}
+									await update();
+								};
+							}}
+						>
+							<input type="hidden" name="bookingId" value={booking.id} />
+							<Button
+								type="submit"
+								class="w-full"
+								disabled={isSubmitting}
+							>
+								{isSubmitting ? 'Accepting...' : 'Accept Request'}
+							</Button>
+						</form>
+						<Button
+							variant="outline"
+							class="flex-1"
+							onclick={() => showRejectConfirm = true}
+							disabled={isSubmitting}
+						>
+							Reject
+						</Button>
+					</div>
 				</div>
 			{/if}
 		</div>

--- a/src/routes/how-it-works/+page.svelte
+++ b/src/routes/how-it-works/+page.svelte
@@ -20,7 +20,7 @@
 				name: 'How do you make money if everything is free?',
 				acceptedAnswer: {
 					'@type': 'Answer',
-					text: 'Currently, we don\'t. LocalSnow is open-source and community-driven. In the future, we may explore optional premium features or ads, but the core platform will always remain 100% free.'
+					text: 'Currently, we don\'t. LocalSnow is open-source and community-driven. While we\'re growing the platform, we\'re keeping it completely free. In the future, we may need to introduce minimal fees to cover costs, but we\'ll give plenty of notice and keep them far below what other platforms charge.'
 				}
 			},
 			{
@@ -85,7 +85,7 @@
 		with students. No booking fees, no commissions, no deposits. Just direct contact.
 	</p>
 
-	<!-- Free Forever Highlight -->
+	<!-- Free Highlight -->
 	<div
 		class="my-8 rounded-lg border-2 border-green-500 bg-gradient-to-r from-green-50 to-blue-50 p-6 not-prose"
 	>
@@ -103,11 +103,11 @@
 				class="text-green-600"
 				><polyline points="20 6 9 17 4 12"></polyline></svg
 			>
-			<h3 class="text-xl font-bold text-green-900 m-0">100% Free. Forever.</h3>
+			<h3 class="text-xl font-bold text-green-900 m-0">100% Free Right Now.</h3>
 		</div>
 		<p class="text-gray-700 m-0">
 			No "trial periods." No "premium plans." No catch. LocalSnow is open-source and
-			community-driven. We don't take commissions, we don't charge fees, and we never will.
+			community-driven. We're keeping it free while we build and grow the platform—no commissions, no fees.
 		</p>
 	</div>
 
@@ -298,7 +298,7 @@
 				<li>✅ <strong>€0 listing fees</strong> - create your profile for free</li>
 				<li>✅ <strong>€0 per booking request</strong> - no lead fees or unlock fees</li>
 				<li>✅ <strong>0% commission</strong> - keep 100% of your lesson fees</li>
-				<li>✅ <strong>No monthly subscriptions</strong> - free forever</li>
+				<li>✅ <strong>No monthly subscriptions</strong> - completely free while we grow</li>
 			</ul>
 		</div>
 	</section>
@@ -320,9 +320,8 @@
 			<div class="rounded-lg border border-border p-5">
 				<h3 class="title4 mb-2">How do you make money if everything is free?</h3>
 				<p class="text-sm text-gray-600 mb-0">
-					Currently, we don't. LocalSnow is <strong>open-source and community-driven</strong>. In
-					the future, we may explore optional premium features or ads, but the core platform will
-					always remain 100% free. We're building the platform we wish existed—not maximizing
+					Currently, we don't. LocalSnow is <strong>open-source and community-driven</strong>. While we're growing the platform, we're keeping it completely free. In
+					the future, we may need to introduce minimal fees to cover costs, but we'll give plenty of notice and keep them far below what other platforms charge. We're building the platform we wish existed—not maximizing
 					profit.
 				</p>
 			</div>


### PR DESCRIPTION
- Update how-it-works page: change "Forever" to "Right Now" and "while we grow"
- Clarify that we may introduce minimal fees in future with notice
- Add Accept button to instructor booking dialog alongside Reject
- Keep booking system fully functional but free of charge
- Maintain instructor ability to accept/reject booking requests