### PR TITLE
Fix: Add missing parentheses to translation function calls in instruc…

### DIFF
--- a/src/routes/instructors/+page.svelte
+++ b/src/routes/instructors/+page.svelte
@@ -289,9 +289,9 @@
 				</Dialog.Trigger>
 				<Dialog.Content class="max-w-lg">
 					<Dialog.Header>
-						<Dialog.Title>{m.instructors_page_advanced_filters}</Dialog.Title>
+						<Dialog.Title>{m.instructors_page_advanced_filters()}</Dialog.Title>
 						<Dialog.Description>
-							{m.instructors_page_refine_search}
+							{m.instructors_page_refine_search()}
 						</Dialog.Description>
 					</Dialog.Header>
 
@@ -330,14 +330,14 @@
 						<div class="flex items-center space-x-2">
 							<Checkbox id="verified" bind:checked={verifiedOnly} />
 							<Label for="verified" class="text-sm font-medium leading-none cursor-pointer">
-								{m.instructors_page_verified_only}
+								{m.instructors_page_verified_only()}
 							</Label>
 						</div>
 					</div>
 
 					<Dialog.Footer>
-						<Button type="button" variant="outline" onclick={clearFilters}>{m.instructors_page_clear_all}</Button>
-						<Button type="button" onclick={applyFilters}>{m.instructors_page_apply_filters}</Button>
+						<Button type="button" variant="outline" onclick={clearFilters}>{m.instructors_page_clear_all()}</Button>
+						<Button type="button" onclick={applyFilters}>{m.instructors_page_apply_filters()}</Button>
 					</Dialog.Footer>
 				</Dialog.Content>
 			</Dialog.Root>
@@ -441,7 +441,7 @@
 			{/if}
 			{#if verifiedOnly}
 				<Badge variant="secondary" class="gap-1">
-					{m.instructors_page_verified_only}
+					{m.instructors_page_verified_only()}
 					<button
 						type="button"
 						onclick={() => removeFilter('verifiedOnly')}
@@ -452,7 +452,7 @@
 				</Badge>
 			{/if}
 			<Button variant="ghost" size="sm" onclick={clearFilters} class="h-6 px-2 text-xs">
-				{m.instructors_page_clear_all}
+				{m.instructors_page_clear_all()}
 			</Button>
 		</div>
 	{/if}
@@ -461,11 +461,11 @@
 	<div class="mb-4 flex items-center justify-between">
 		<p class="text-muted-foreground text-sm">
 			{#if data.instructors.length === 0}
-				{m.instructors_page_results_none}
+				{m.instructors_page_results_none()}
 			{:else if data.instructors.length === 1}
-				{m.instructors_page_results_one}
+				{m.instructors_page_results_one()}
 			{:else}
-				{data.instructors.length} {m.instructors_page_results_many}
+				{data.instructors.length} {m.instructors_page_results_many()}
 			{/if}
 		</p>
 	</div>
@@ -487,9 +487,9 @@
 					d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
 				/>
 			</svg>
-			<h3 class="mb-2 text-lg font-semibold">{m.instructors_page_empty_title}</h3>
-			<p class="text-muted-foreground mb-4">{m.instructors_page_empty_subtitle}</p>
-			<Button onclick={clearFilters} variant="outline">{m.instructors_page_empty_clear_filters}</Button>
+			<h3 class="mb-2 text-lg font-semibold">{m.instructors_page_empty_title()}</h3>
+			<p class="text-muted-foreground mb-4">{m.instructors_page_empty_subtitle()}</p>
+			<Button onclick={clearFilters} variant="outline">{m.instructors_page_empty_clear_filters()}</Button>
 		</div>
 	{:else}
 		<div class="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-2">

--- a/src/routes/instructors/[id]/+page.svelte
+++ b/src/routes/instructors/[id]/+page.svelte
@@ -260,9 +260,9 @@
 				<!-- Instructor Type Badge -->
 				<div class="mt-4">
 					{#if isIndependent}
-						<Badge variant="secondary" class="text-sm">{m.badge_independent_instructor}</Badge>
+						<Badge variant="secondary" class="text-sm">{m.badge_independent_instructor()}</Badge>
 					{:else}
-						<Badge variant="secondary" class="text-sm">{m.badge_school_instructor}</Badge>
+						<Badge variant="secondary" class="text-sm">{m.badge_school_instructor()}</Badge>
 					{/if}
 				</div>
 			</div>
@@ -311,7 +311,7 @@
 							d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"
 						/>
 					</svg>
-					<span class="text-sm">{m.instructor_response_time}</span>
+					<span class="text-sm">{m.instructor_response_time()}</span>
 				</div>
 			</div>
 		</div>
@@ -323,15 +323,15 @@
 			{#if data.baseLesson && !data.groupTiers?.length && !data.durationPackages?.length }
 				<div class="w-full rounded-lg border border-primary/20 bg-card p-4">
 					<div class="mb-2 flex items-center justify-between">
-						<span class="text-sm font-medium">{m.lessons_hourly_rate_label}</span>
-						<Badge variant="secondary" class="text-xs">{m.badge_from}</Badge>
+						<span class="text-sm font-medium">{m.lessons_hourly_rate_label()}</span>
+						<Badge variant="secondary" class="text-xs">{m.badge_from()}</Badge>
 					</div>
 					<div class="flex items-baseline gap-2">
 						<span class="text-2xl font-bold text-primary">{data.baseLesson.basePrice}</span>
 						<span class="text-sm text-muted-foreground">{data.baseLesson.currency}/h</span>
 					</div>
 					<p class="mt-2 text-xs text-muted-foreground">
-						{m.instructor_base_rate_help}
+						{m.instructor_base_rate_help()}
 					</p>
 				</div>
 			{/if}
@@ -361,7 +361,7 @@
 								d="M13 10V3L4 14h7v7l9-11h-7z"
 							/>
 						</svg>
-						{m.instructor_sports_offered}
+						{m.instructor_sports_offered()}
 					</h2>
 					<div class="flex flex-wrap gap-2">
 						{#each sports as sport}


### PR DESCRIPTION
…tors routes

Fixed translation functions that were showing raw function code instead of translated text by adding missing parentheses () to invoke the functions.

Changes:
- src/routes/instructors/+page.svelte: Fixed 11 translation function calls
  - instructors_page_verified_only (3 instances)
  - instructors_page_clear_all (2 instances)
  - instructors_page_apply_filters
  - instructors_page_results_none
  - instructors_page_results_one
  - instructors_page_results_many
  - instructors_page_empty_title
  - instructors_page_empty_subtitle
  - instructors_page_empty_clear_filters
  - instructors_page_advanced_filters
  - instructors_page_refine_search

- src/routes/instructors/[id]/+page.svelte: Fixed 7 translation function calls
  - badge_independent_instructor
  - badge_school_instructor
  - instructor_response_time
  - lessons_hourly_rate_label
  - badge_from
  - instructor_base_rate_help
  - instructor_sports_offered

All translation functions now properly invoke and return translated strings.