### PR TITLE
Test: Temporarily disable Traefik buffering middleware

### DIFF
--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -225,13 +225,14 @@ services:
         - "traefik.http.middlewares.localsnow-www-redirect.redirectregex.permanent=true"
 
         # Buffering Middleware - Allow larger request bodies (20MB for file uploads)
-        - "traefik.http.middlewares.localsnow-buffering.buffering.maxRequestBodyBytes=20000000"
-        - "traefik.http.middlewares.localsnow-buffering.buffering.memRequestBodyBytes=2000000"
-        - "traefik.http.middlewares.localsnow-buffering.buffering.maxResponseBodyBytes=20000000"
-        - "traefik.http.middlewares.localsnow-buffering.buffering.memResponseBodyBytes=2000000"
+        # TEMPORARILY DISABLED TO TEST IF THIS CAUSES ROOT PATH REDIRECT ISSUE
+        # - "traefik.http.middlewares.localsnow-buffering.buffering.maxRequestBodyBytes=20000000"
+        # - "traefik.http.middlewares.localsnow-buffering.buffering.memRequestBodyBytes=2000000"
+        # - "traefik.http.middlewares.localsnow-buffering.buffering.maxResponseBodyBytes=20000000"
+        # - "traefik.http.middlewares.localsnow-buffering.buffering.memResponseBodyBytes=2000000"
 
         # Apply all middlewares to router
-        - "traefik.http.routers.localsnow.middlewares=localsnow-www-redirect,localsnow-security,localsnow-buffering"
+        - "traefik.http.routers.localsnow.middlewares=localsnow-www-redirect,localsnow-security"
 
         # Docker Swarm specific - use overlay network
         - "traefik.docker.network=proxy"


### PR DESCRIPTION
The root path redirect issue started appearing ~1hr after the buffering middleware was added on Jan 17th at 18:20. First debug attempt for the issue was at 19:36.

Timeline:
- 18:20: Buffering middleware added
- 19:36: First "Fix root path 500 error" commit

This timing suggests the buffering middleware might be interfering with SvelteKit's redirect responses at the root path.

Testing by temporarily disabling buffering to see if root path redirect works without it. If it works, we'll need to find an alternative approach for handling large file uploads.