### PR TITLE
Add BODY_SIZE_LIMIT env var to allow 20MB uploads

### DIFF
--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -139,6 +139,8 @@ services:
       ORIGIN: https://localsnow.org
       PROTOCOL_HEADER: x-forwarded-proto
       HOST_HEADER: x-forwarded-host
+      # Allow file uploads up to 20MB (instructor signup: 5MB image + 10MB PDF)
+      BODY_SIZE_LIMIT: 20M
 
       # Point to Docker secret files
       # Our config.ts reads these _FILE env vars and loads the secret files


### PR DESCRIPTION
Use SvelteKit's BODY_SIZE_LIMIT environment variable to override the default 512KB request body limit without requiring Docker image rebuild.

This allows immediate deployment of the fix for instructor signup forms with large file uploads (5MB images + 10MB PDFs).

Set to 20M (20 megabytes) using the unit suffix as documented in adapter-node environment variables documentation.