### PR TITLE
Fix crash when Google OAuth claims missing family_name

### DIFF
--- a/src/lib/server/google/oauth.ts
+++ b/src/lib/server/google/oauth.ts
@@ -40,7 +40,7 @@ export type GoogleClaims = {
 	name: string,
 	picture: string,
 	given_name: string,
-	family_name: string,
+	family_name?: string,
 	iat: number,
 	exp: number
 }

--- a/src/lib/utils/generics.ts
+++ b/src/lib/utils/generics.ts
@@ -33,7 +33,7 @@ export function generateUsernameFromGoogle(claims: GoogleClaims) {
 
     // Format name and surname
     const formattedName = claims.given_name.toLowerCase();
-    const firstLetterSurname = claims.family_name.charAt(0).toLowerCase();
+    const firstLetterSurname = claims.family_name ? claims.family_name.charAt(0).toLowerCase() : '';
 
     // Combine into username
     return `${formattedName}${firstLetterSurname}${lastThreeDigits}`;


### PR DESCRIPTION
Google doesn't always return family_name (e.g. single-name accounts).
Mark it optional in GoogleClaims type and guard against undefined in
generateUsernameFromGoogle before calling .charAt().

Fixes: TypeError: Cannot read properties of undefined (reading 'charAt')

https://claude.ai/code/session_01NhSp4zWT2UWBJAawAbkUxj