### PR TITLE
fix: keep LocalSnow Swarm services retrying

### DIFF
--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -96,7 +96,9 @@ services:
       restart_policy:
         condition: on-failure
         delay: 5s
-        max_attempts: 3
+        # Keep retrying after transient Docker/daemon failures. A finite
+        # retry cap can leave the service permanently down until an
+        # operator forces an update.
       resources:
         limits:
           memory: 1G
@@ -184,7 +186,9 @@ services:
       restart_policy:
         condition: on-failure
         delay: 5s
-        max_attempts: 3
+        # Keep retrying after transient Docker/daemon failures. A finite
+        # retry cap can leave the service permanently down until an
+        # operator forces an update.
         window: 120s
 
       # Resource limits


### PR DESCRIPTION
## Summary
- Removes finite Swarm restart retry caps from `localsnow_postgres` and `localsnow_app`
- Prevents transient Docker/daemon/container failures from leaving LocalSnow permanently at 0 replicas until an operator forces an update

## Production context
- Production was found down with `localsnow_app` at `0/2` and `localsnow_postgres` at `0/1`
- App logs showed `getaddrinfo ENOTFOUND postgres` because Postgres had exhausted restart attempts and was not running/resolvable
- I restored service now with `docker service update --force localsnow_postgres` then `docker service update --force localsnow_app`

## Verification
- `git diff --check`
- `docker stack config -c docker-compose.production.yml` validated on the VPS Docker engine without deploying
- `https://localsnow.org/api/health` returned HTTP 200 with database/application ok
- VPS service state after manual recovery: `localsnow_app 2/2`, `localsnow_postgres 1/1`, containers healthy

## Deploy note
Merging to `main` will trigger the existing GitHub Actions production deploy. I have not merged this PR.
