### PR TITLE
ci: use package PAT for GHCR publish

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,8 +20,11 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          # The image is published under Dave's GHCR namespace, not the repo owner.
+          # Use the existing package PAT instead of the repo-scoped GITHUB_TOKEN,
+          # which cannot push this package reliably after the repo/org move.
+          username: dvemolina
+          password: ${{ secrets.GIT_PAT }}
 
       - name: Build and Push Docker Image
         uses: docker/build-push-action@v6
@@ -43,8 +46,8 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: dvemolina
+          password: ${{ secrets.GIT_PAT }}
 
       - name: Create environment file
         run: |
@@ -59,9 +62,9 @@ jobs:
           port: ${{ secrets.DEPLOY_PORT }}
           user: ${{ secrets.DEPLOY_USER }}
           ssh_key: ${{ secrets.DEPLOY_SSH_PRIVATE_KEY }}
-          env_file: ./envfile'
+          env_file: ./envfile
           registry_host: 'ghcr.io'
-          registry_user: ${{ github.actor }}
+          registry_user: dvemolina
           registry_pass: ${{ secrets.GIT_PAT }}
           summary: true
 


### PR DESCRIPTION
## Summary
- use the existing `GIT_PAT` package token for GHCR login in the build/publish job
- pin GHCR username to `dvemolina`, matching the hardcoded image namespace `ghcr.io/dvemolina/localsnow`
- apply the same registry credentials to the deploy job
- remove a stray quote from `env_file: ./envfile`

## Root cause
The failed main-branch deploy did not reach the VPS deploy step. It failed while pushing the Docker image:

```text
ERROR: failed to build: denied: permission_denied: The requested installation does not exist.
```

The workflow was authenticating to GHCR with the repo-scoped `${{ secrets.GITHUB_TOKEN }}` but publishing to Dave's GHCR namespace (`ghcr.io/dvemolina/localsnow`). After the repo/org move, that token cannot reliably write that package. The workflow already had `GIT_PAT` for registry access, so the build/push step should use it too.

## Verification
- Parsed `.github/workflows/deploy.yml` with Python/YAML.
- Asserted build GHCR login uses `username: dvemolina` and `password: ${{ secrets.GIT_PAT }}`.
- Asserted stack deploy `env_file` is `./envfile` and registry user is `dvemolina`.

## Deploy note
Merging this PR will trigger the main-branch production deploy again.